### PR TITLE
gpio: en7523/an7581: fix direction set/query

### DIFF
--- a/target/linux/airoha/dts/en7581.dtsi
+++ b/target/linux/airoha/dts/en7581.dtsi
@@ -278,9 +278,18 @@
 			reg = <0 0x1fbf0204 0 0x4>,
 			      <0 0x1fbf0200 0 0x4>,
 			      <0 0x1fbf0220 0 0x4>,
-			      <0 0x1fbf0214 0 0x4>;
+			      <0 0x1fbf0214 0 0x4>,
+			      <0 0x1fbf0208 0 0x4>, /* Interrupt status register */
+			      <0 0x1fbf0210 0 0x4>, /* Level 0 */
+			      <0 0x1fbf028C 0 0x4>, /* Level 1 */
+			      <0 0x1fbf020C 0 0x4>, /* Edge 0 */
+			      <0 0x1fbf0280 0 0x4>; /* Edge 1 */
 			gpio-controller;
 			#gpio-cells = <2>;
+			interrupt-controller;
+			#interrupt-cells = <2>;
+			interrupt-parent = <&gic>;
+			interrupts = <GIC_SPI 26 IRQ_TYPE_LEVEL_HIGH>;
 		};
 
 		gpio1: gpio@1fbf0270 {
@@ -288,9 +297,18 @@
 			reg = <0 0x1fbf0270 0 0x4>,
 			      <0 0x1fbf0260 0 0x4>,
 			      <0 0x1fbf0264 0 0x4>,
-			      <0 0x1fbf0278 0 0x4>;
+			      <0 0x1fbf0278 0 0x4>,
+			      <0 0x1fbf027C 0 0x4>, /* Interrupt status register */
+			      <0 0x1fbf0290 0 0x4>, /* Level 0 */
+			      <0 0x1fbf0294 0 0x4>, /* Level 1 */
+			      <0 0x1fbf0284 0 0x4>, /* Edge 0 */
+			      <0 0x1fbf0288 0 0x4>; /* Edge 1 */
 			gpio-controller;
 			#gpio-cells = <2>;
+			interrupt-controller;
+			#interrupt-cells = <2>;
+			interrupt-parent = <&gic>;
+			interrupts = <GIC_SPI 26 IRQ_TYPE_LEVEL_HIGH>;
 		};
 
 		pciephy: phy@1fa5a000 {

--- a/target/linux/airoha/patches-6.1/0005-gpio-irq.patch
+++ b/target/linux/airoha/patches-6.1/0005-gpio-irq.patch
@@ -1,0 +1,255 @@
+Index: linux-airoha_en7581/linux-6.1.65/drivers/gpio/gpio-en7523.c
+===================================================================
+--- a/drivers/gpio/gpio-en7523.c
++++ b/drivers/gpio/gpio-en7523.c
+@@ -3,9 +3,13 @@
+ #include <linux/types.h>
+ #include <linux/io.h>
+ #include <linux/bits.h>
++#include <linux/interrupt.h>
+ #include <linux/gpio/driver.h>
+ #include <linux/mod_devicetable.h>
+ #include <linux/module.h>
++#include <linux/of_irq.h>
++#include <linux/irq.h>
++#include <linux/irqdomain.h>
+ #include <linux/platform_device.h>
+ #include <linux/property.h>
+
+@@ -18,12 +22,34 @@
+  * @dir0: The direction register for the lower 16 pins.
+  * @dir1: The direction register for the higher 16 pins.
+  * @output: The output enable register.
++ * @irqstatus: The IRQ status register.
++ * @level0: The level trigger register for the lower 16 pins.
++ * @level1: The level trigger register for the higher 16 pins.
++ * @edge0: The edge trigger register for the lower 16 pins.
++ * @edge1: The edge trigger register for the higher 16 pins.
++ * @gpio_irq: Shared interrupt number.
++ * @lock: spinlock for interrupt handling.
++ * @rising: Rising edge interrupt enabled.
++ * @falling: Falling edge interrupt enabled.
++ * @level_high: Level high interrupt enabled.
++ * @level_low: Level low interrupt enabled.
+  */
+ struct airoha_gpio_ctrl {
+ 	struct gpio_chip gc;
+ 	void __iomem *data;
+ 	void __iomem *dir[2];
+ 	void __iomem *output;
++
++	void __iomem *irqstatus;
++	void __iomem *level[2];
++	void __iomem *edge[2];
++
++	int gpio_irq;
++	spinlock_t lock;
++	u32 rising;
++	u32 falling;
++	u32 level_high;
++	u32 level_low;
+ };
+
+ static struct airoha_gpio_ctrl *gc_to_ctrl(struct gpio_chip *gc)
+@@ -85,9 +111,137 @@ static int airoha_get_dir(struct gpio_ch
+ 	return -EINVAL;
+ }
+
++static irqreturn_t airoha_gpio_irq_handler(int irq, void *data)
++{
++	struct gpio_chip *gc = data;
++	struct airoha_gpio_ctrl *ctrl = gc_to_ctrl(gc);
++	unsigned long pending;
++	int bit;
++
++	pending = ioread32(ctrl->irqstatus);
++	if(!pending)
++		return IRQ_NONE;
++
++	for_each_set_bit(bit, &pending, AIROHA_GPIO_MAX) {
++		u32 map = irq_find_mapping(gc->irq.domain, bit);
++
++		generic_handle_irq(map);
++		iowrite32(BIT(bit), ctrl->irqstatus);
++	}
++
++	return IRQ_HANDLED;
++}
++
++static void airoha_gpio_irq_unmask(struct irq_data *data)
++{
++	struct airoha_gpio_ctrl *ctrl = irq_data_get_irq_chip_data(data);
++	int pin = data->hwirq;
++	unsigned long flags;
++	u32 tmp;
++	u32 mask = BIT((pin % 16) * 2) | (BIT((pin % 16) * 2) << 1);
++
++	spin_lock_irqsave(&ctrl->lock, flags);
++
++	tmp = ioread32(ctrl->edge[(pin / 16) % 2]);
++	tmp &= ~mask;
++	if (BIT(pin) & ctrl->rising)
++		tmp |= BIT((pin % 16) * 2);
++	if (BIT(pin) & ctrl->falling)
++		tmp |= (BIT((pin % 16) * 2)) << 1;
++	iowrite32(tmp, ctrl->edge[(pin / 16) % 2]);
++
++	tmp = ioread32(ctrl->level[(pin / 16) % 2]);
++	tmp &= ~mask;
++	if (BIT(pin) & ctrl->level_high)
++		tmp |= BIT((pin % 16) * 2);
++	if (BIT(pin) & ctrl->level_low)
++		tmp |= (BIT((pin % 16) * 2)) << 1;
++	iowrite32(tmp, ctrl->level[(pin / 16) % 2]);
++
++	spin_unlock_irqrestore(&ctrl->lock, flags);
++}
++
++static void airoha_gpio_irq_mask(struct irq_data *data)
++{
++	struct airoha_gpio_ctrl *ctrl = irq_data_get_irq_chip_data(data);
++	int pin = data->hwirq;
++	unsigned long flags;
++	u32 tmp;
++	u32 mask = BIT((pin % 16) * 2) | (BIT((pin % 16) * 2) << 1);
++
++	spin_lock_irqsave(&ctrl->lock, flags);
++
++	tmp = ioread32(ctrl->edge[(pin / 16) % 2]);
++	tmp &= ~mask;
++	iowrite32(tmp, ctrl->edge[(pin / 16) % 2]);
++
++	tmp = ioread32(ctrl->level[(pin / 16) % 2]);
++	tmp &= ~mask;
++	iowrite32(tmp, ctrl->level[(pin / 16) % 2]);
++
++	spin_unlock_irqrestore(&ctrl->lock, flags);
++}
++
++static int airoha_gpio_irq_type(struct irq_data *data, unsigned int type)
++{
++	struct airoha_gpio_ctrl *ctrl = irq_data_get_irq_chip_data(data);
++	int pin = data->hwirq;
++	unsigned long flags;
++	u32 mask = BIT(pin);
++
++	spin_lock_irqsave(&ctrl->lock, flags);
++
++	if (type == IRQ_TYPE_PROBE) {
++		if ((ctrl->rising | ctrl->falling | ctrl->level_high | ctrl->level_low) & mask)
++			goto out;
++
++		type = IRQ_TYPE_EDGE_RISING | IRQ_TYPE_EDGE_FALLING;
++	}
++
++	ctrl->rising &= ~mask;
++	ctrl->falling &= ~mask;
++	ctrl->level_high &= ~mask;
++	ctrl->level_low &= ~mask;
++
++	switch (type & IRQ_TYPE_SENSE_MASK) {
++	case IRQ_TYPE_EDGE_BOTH:
++		ctrl->rising |= mask;
++		ctrl->falling |= mask;
++		break;
++	case IRQ_TYPE_EDGE_RISING:
++		ctrl->rising |= mask;
++		break;
++	case IRQ_TYPE_EDGE_FALLING:
++		ctrl->falling |= mask;
++		break;
++	case IRQ_TYPE_LEVEL_HIGH:
++		ctrl->level_high |= mask;
++		break;
++	case IRQ_TYPE_LEVEL_LOW:
++		ctrl->level_low |= mask;
++		break;
++	}
++
++out:
++	spin_unlock_irqrestore(&ctrl->lock, flags);
++
++	return 0;
++}
++
++static struct irq_chip en7523_irq_chip = {
++	.name		= "en7523-gpio-irq",
++	.irq_unmask	= airoha_gpio_irq_unmask,
++	.irq_mask	= airoha_gpio_irq_mask,
++	.irq_mask_ack	= airoha_gpio_irq_mask,
++	.irq_set_type	= airoha_gpio_irq_type,
++	.flags		= IRQCHIP_SET_TYPE_MASKED,
++};
++
++
+ static int airoha_gpio_probe(struct platform_device *pdev)
+ {
+ 	struct device *dev = &pdev->dev;
++	struct device_node *np = dev->of_node;
+ 	struct airoha_gpio_ctrl *ctrl;
+ 	int err;
+
+@@ -122,6 +276,63 @@ static int airoha_gpio_probe(struct plat
+ 	ctrl->gc.direction_input = airoha_dir_in;
+ 	ctrl->gc.get_direction = airoha_get_dir;
+
++	spin_lock_init(&ctrl->lock);
++
++	if (of_find_property(np, "interrupt-controller", NULL)) {
++		struct gpio_irq_chip *girq = NULL;
++		int ret = platform_get_irq(pdev, 0);
++
++		if (ret < 0) {
++			dev_err(dev, "Error requesting IRQ %d\n", ret);
++			return ret;
++		}
++		ctrl->gpio_irq = ret;
++
++		ctrl->irqstatus = devm_platform_ioremap_resource(pdev, 4);
++		if (IS_ERR(ctrl->irqstatus))
++			return PTR_ERR(ctrl->irqstatus);
++
++		ctrl->level[0] = devm_platform_ioremap_resource(pdev, 5);
++		if (IS_ERR(ctrl->level[0]))
++			return PTR_ERR(ctrl->level[0]);
++
++		ctrl->level[1] = devm_platform_ioremap_resource(pdev, 6);
++		if (IS_ERR(ctrl->level[1]))
++			return PTR_ERR(ctrl->level[1]);
++
++		ctrl->edge[0] = devm_platform_ioremap_resource(pdev, 7);
++		if (IS_ERR(ctrl->edge[0]))
++			return PTR_ERR(ctrl->edge[0]);
++
++		ctrl->edge[1] = devm_platform_ioremap_resource(pdev, 8);
++		if (IS_ERR(ctrl->edge[1]))
++			return PTR_ERR(ctrl->edge[1]);
++
++		/*
++		 * Directly request the irq here instead of passing
++		 * a flow-handler because the irq is shared.
++		 */
++		ret = devm_request_irq(dev, ctrl->gpio_irq, airoha_gpio_irq_handler, IRQF_SHARED, dev_name(dev), &ctrl->gc);
++		if (ret) {
++			dev_err(dev, "Error requesting IRQ %d: %d\n", ctrl->gpio_irq, ret);
++			return ret;
++		}
++
++		girq = &ctrl->gc.irq;
++
++		girq->chip = devm_kzalloc(dev, sizeof(en7523_irq_chip), GFP_KERNEL);
++		if (!girq->chip)
++			return -ENOMEM;
++		memcpy(girq->chip, &en7523_irq_chip, sizeof(en7523_irq_chip));
++
++		/* This will let us handle the parent IRQ in the driver */
++		girq->parent_handler = NULL;
++		girq->num_parents = 0;
++		girq->parents = NULL;
++		girq->default_type = IRQ_TYPE_NONE;
++		girq->handler = handle_simple_irq;
++	}
++
+ 	return devm_gpiochip_add_data(dev, &ctrl->gc, ctrl);
+ }
+


### PR DESCRIPTION
GPIO Control Register uses 2 bits to specify gpio pin function. This results in 4 possible values:
  0: GPIO input mode.
  1: GPIO output mode.
  2: Reserved
  3: Reserved

It may be noted, that only low bit is used to specify pin function. High bit is reserved and should be zero.

It was noted that some gpio have non-zero reserved bit by default. Current GPIO driver does not touch reserved bit. As result it was not possible to configure as input/output pins with non-zero reserved bit.

Fix an issue by always zero reserved bit.